### PR TITLE
Add a UseNServiceBusAmazonSqsEndpoint extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In all cases, the endpoint will retrieve configuration values from the `IConfigu
 
 ## Supported endpoints
 
-For more information on all the supported endpoints, refer to the [Mattox.Endpoints](https://github.com/mauroservienti/Mattox.Endpoints#supported-endpoints) repository.
+For more information on all the supported endpoints, refer to the [Mattox.NServiceBus](https://github.com/mauroservienti/Mattox.NServiceBus#supported-endpoints) repository.
 
 ## How to get it
 

--- a/README.md
+++ b/README.md
@@ -7,29 +7,53 @@ Mattox Endpoints simplify [NServiceBus endpoints](https://docs.particular.net/ns
 Creating and starting an Amazon SQS endpoint is as easy as:
 
 <!-- snippet: BasicEndpointUsage -->
-<a id='snippet-basicendpointusage'></a>
+<a id='snippet-BasicEndpointUsage'></a>
 ```cs
 var endpoint = new AmazonSqsEndpoint("my-endpoint");
 var endpointInstance = await endpoint.Start();
 ```
-<sup><a href='/src/Snippets/BasicEndpoint.cs#L9-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-basicendpointusage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/BasicEndpoint.cs#L9-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-BasicEndpointUsage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Microsoft configuration extension support
 
 Mattox endpoints can be configured through the [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration). The above-presented Amazon SQS endpoint can be configured as follows:
 
+<!-- snippet: UseWithHostUseNServiceBusAmazonSqsEndpoint -->
+<a id='snippet-UseWithHostUseNServiceBusAmazonSqsEndpoint'></a>
+```cs
+Host.CreateDefaultBuilder()
+    .UseNServiceBusAmazonSqsEndpoint()
+    .Build();
+```
+<sup><a href='/src/Snippets/UseWithHost.cs#L17-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-UseWithHostUseNServiceBusAmazonSqsEndpoint' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+If the endpoint name must be specified in code, the following overload can be used:
+
+<!-- snippet: UseWithHostUseNServiceBusAmazonSqsEndpointWithEndpointName -->
+<a id='snippet-UseWithHostUseNServiceBusAmazonSqsEndpointWithEndpointName'></a>
+```cs
+Host.CreateDefaultBuilder()
+    .UseNServiceBusAmazonSqsEndpoint("MyEndpointName")
+    .Build();
+```
+<sup><a href='/src/Snippets/UseWithHost.cs#L23-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-UseWithHostUseNServiceBusAmazonSqsEndpointWithEndpointName' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+if there is a need to access the host builder context before creating the endpoint, the following approach can be used:
+
 <!-- snippet: UseWithHost -->
-<a id='snippet-usewithhost'></a>
+<a id='snippet-UseWithHost'></a>
 ```cs
 Host.CreateDefaultBuilder()
     .UseNServiceBus(hostBuilderContext => new AmazonSqsEndpoint(hostBuilderContext.Configuration))
     .Build();
 ```
-<sup><a href='/src/Snippets/UseWithHost.cs#L11-L15' title='Snippet source file'>snippet source</a> | <a href='#snippet-usewithhost' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/UseWithHost.cs#L11-L15' title='Snippet source file'>snippet source</a> | <a href='#snippet-UseWithHost' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The endpoint will retrieve values from the `IConfiguration` object instance.
+In all cases, the endpoint will retrieve configuration values from the `IConfiguration` object instance.
 
 ## Supported endpoints
 
@@ -39,12 +63,6 @@ For more information on all the supported endpoints, refer to the [Mattox.Endpoi
 
 - Pre-releases are available on [Feedz.io](https://feedz.io/) ([public feed](https://f.feedz.io/mauroservienti/pre-releases/nuget/index.json))
 - Releases on [NuGet.org](https://www.nuget.org/packages?q=Mattox)
-
-
-
-
-
-
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="assets/icon.png" width="100" />
 
-# NServiceBoXes.Endpoints.AmazonSQS
+# Mattox.Endpoints.AmazonSQS
 
-NServiceBoXes Endpoints simplify [NServiceBus endpoints](https://docs.particular.net/nservicebus/) configuration by providing for supported transports a corresponding NServiceBoXes endpoint with sensible defaults. `NServiceBoXes.Endpoints.AmazonSQS` is the NServiceBoXes endpoint for the [NServiceBus AmamzonSQS transport](https://docs.particular.net/transports/sqs/).
+Mattox Endpoints simplify [NServiceBus endpoints](https://docs.particular.net/nservicebus/) configuration by providing for supported transports a corresponding Mattox endpoint with sensible defaults. `Mattox.Endpoints.AmazonSQS` is the Mattox endpoint for the [NServiceBus AmamzonSQS transport](https://docs.particular.net/transports/sqs/).
 
 Creating and starting an Amazon SQS endpoint is as easy as:
 
@@ -17,7 +17,7 @@ var endpointInstance = await endpoint.Start();
 
 ## Microsoft configuration extension support
 
-NServiceBoXes endpoints can be configured through the [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration). The above-presented Amazon SQS endpoint can be configured as follows:
+Mattox endpoints can be configured through the [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration). The above-presented Amazon SQS endpoint can be configured as follows:
 
 <!-- snippet: UseWithHost -->
 <a id='snippet-usewithhost'></a>
@@ -33,12 +33,12 @@ The endpoint will retrieve values from the `IConfiguration` object instance.
 
 ## Supported endpoints
 
-For more information on all the supported endpoints, refer to the [NServiceBoXes.Endpoints](https://github.com/mauroservienti/NServiceBoXes.Endpoints#supported-endpoints) repository.
+For more information on all the supported endpoints, refer to the [Mattox.Endpoints](https://github.com/mauroservienti/Mattox.Endpoints#supported-endpoints) repository.
 
 ## How to get it
 
 - Pre-releases are available on [Feedz.io](https://feedz.io/) ([public feed](https://f.feedz.io/mauroservienti/pre-releases/nuget/index.json))
-- Releases on [NuGet.org](https://www.nuget.org/packages?q=NServiceBoXes)
+- Releases on [NuGet.org](https://www.nuget.org/packages?q=Mattox)
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Configuration
 
-NServiceBoXes endpoints can be configured through the [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration). All settings are defined in the `NServiceBus:EndpointConfiguration` section. All endpoints share settings comning from the upstream [NServiceBoXes.Endpoints](https://github.com/mauroservienti/NServiceBoXes.Endpoints) package. For more details look at the [documentation in the NServiceBoXes.Endpoints repository](https://github.com/mauroservienti/NServiceBoXes.Endpoints/tree/main/docs).
+Mattox endpoints can be configured through the [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration). All settings are defined in the `NServiceBus:EndpointConfiguration` section. All endpoints share settings comning from the upstream [Mattox.Endpoints](https://github.com/mauroservienti/Mattox.NServiceBus) package. For more details look at the [documentation in the Mattox.Endpoints repository](https://github.com/mauroservienti/Mattox.NServiceBus/tree/main/docs).
 
-The NServiceBoXes.Endpoints.AmazonSQS endpoint supports the following configuration options.
+The Mattox.Endpoints.AmazonSQS endpoint supports the following configuration options.
 
 - `NServiceBus:EndpointConfiguration:Transport:QueueNamePrefix` allows controlling the [queue name prefix](https://docs.particular.net/transports/sqs/configuration-options#queuenameprefix) used by the transport to locate queues.
 - `NServiceBus:EndpointConfiguration:Transport:TopicNamePrefix` allows controlling the [topic name prefix](https://docs.particular.net/transports/sqs/configuration-options#topicnameprefix) used by the transport to locate topics.

--- a/src/NServiceBoXes.Endpoints.AmazonSQS/HostBuilderExtensions.cs
+++ b/src/NServiceBoXes.Endpoints.AmazonSQS/HostBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+namespace NServiceBoXes.Endpoints.AmazonSQS;
+
+public static class HostBuilderExtensions
+{
+    public static IHostBuilder UseNServiceBusAmazonSqsEndpoint(this IHostBuilder builder, Action<AmazonSqsEndpoint>? endpoint)
+    {
+        builder.UseNServiceBus(hostBuilderContext=>
+        {
+            var ep = new AmazonSqsEndpoint(hostBuilderContext.Configuration);
+            endpoint?.Invoke(ep);
+
+            return ep;
+        });
+        
+        return builder;
+    }
+}

--- a/src/NServiceBoXes.Endpoints.AmazonSQS/HostBuilderExtensions.cs
+++ b/src/NServiceBoXes.Endpoints.AmazonSQS/HostBuilderExtensions.cs
@@ -5,11 +5,24 @@ namespace NServiceBoXes.Endpoints.AmazonSQS;
 
 public static class HostBuilderExtensions
 {
-    public static IHostBuilder UseNServiceBusAmazonSqsEndpoint(this IHostBuilder builder, Action<AmazonSqsEndpoint>? endpoint)
+    public static IHostBuilder UseNServiceBusAmazonSqsEndpoint(this IHostBuilder builder, Action<AmazonSqsEndpoint>? endpoint = null)
     {
         builder.UseNServiceBus(hostBuilderContext=>
         {
             var ep = new AmazonSqsEndpoint(hostBuilderContext.Configuration);
+            endpoint?.Invoke(ep);
+
+            return ep;
+        });
+        
+        return builder;
+    }
+    
+    public static IHostBuilder UseNServiceBusAmazonSqsEndpoint(this IHostBuilder builder, string endpointName, Action<AmazonSqsEndpoint>? endpoint = null)
+    {
+        builder.UseNServiceBus(hostBuilderContext=>
+        {
+            var ep = new AmazonSqsEndpoint(endpointName, hostBuilderContext.Configuration);
             endpoint?.Invoke(ep);
 
             return ep;

--- a/src/NServiceBoXes.Endpoints.AmazonSQS/NServiceBoXes.Endpoints.AmazonSQS.csproj
+++ b/src/NServiceBoXes.Endpoints.AmazonSQS/NServiceBoXes.Endpoints.AmazonSQS.csproj
@@ -37,6 +37,7 @@
     <ItemGroup>
       <PackageReference Include="NServiceBoXes.Endpoints" Version="0.0.3" />
       <PackageReference Include="NServiceBus.AmazonSQS" Version="[6.1.1, 7.0.0)" />
+      <PackageReference Include="NServiceBus.Extensions.Hosting" Version="[2.0.0, 3.0.0)" />
     </ItemGroup>
 
 

--- a/src/Snippets/UseWithHost.cs
+++ b/src/Snippets/UseWithHost.cs
@@ -13,5 +13,17 @@ public class UseWithHost
             .UseNServiceBus(hostBuilderContext => new AmazonSqsEndpoint(hostBuilderContext.Configuration))
             .Build();
         // end-snippet
+        
+        // begin-snippet: UseWithHostUseNServiceBusAmazonSqsEndpoint
+        Host.CreateDefaultBuilder()
+            .UseNServiceBusAmazonSqsEndpoint()
+            .Build();
+        // end-snippet
+        
+        // begin-snippet: UseWithHostUseNServiceBusAmazonSqsEndpointWithEndpointName
+        Host.CreateDefaultBuilder()
+            .UseNServiceBusAmazonSqsEndpoint("MyEndpointName")
+            .Build();
+        // end-snippet
     }
 }


### PR DESCRIPTION
Fix #33 

I don't like:

- the lowercase `Sqs` in the method name
- the dependency on `NServiceBus.Extensions.Hosting`